### PR TITLE
remove not stated from summary of nationality

### DIFF
--- a/apps/pttg-rps-enquiry-form/fields/fields.js
+++ b/apps/pttg-rps-enquiry-form/fields/fields.js
@@ -15,7 +15,7 @@ module.exports = {
     },
     'enter-nationality': {
         mixin: 'select',
-        options: [{label:' ', value: ''}].concat(require('hof-util-countries')())
+        options: [{label: ' ', value: ''}].concat(require('hof-util-countries')())
     },
     'enter-phone-number': {
         mixin: 'input-phone',


### PR DESCRIPTION
Ive left it as it was except replace the message with an empty string. I prefer to leave an empty option in the list as without it forces the user to pick a country. Many will not notice the option to click 'nationality not specified' as I didn't.