### PR TITLE
EE-8231 Add check box for asking question as proxy

### DIFF
--- a/apps/pttg-rps-enquiry-form/fields/fields.js
+++ b/apps/pttg-rps-enquiry-form/fields/fields.js
@@ -54,6 +54,9 @@ module.exports = {
             {type: 'before'},
             {type: 'after', arguments: '1903-01-01'}
         ]
-    })
-
+    }),
+    'is-proxy': {
+        className: 'label',
+        mixin: 'checkbox'
+    }
 };

--- a/apps/pttg-rps-enquiry-form/pages/question.js
+++ b/apps/pttg-rps-enquiry-form/pages/question.js
@@ -4,6 +4,7 @@ module.exports = {
     path: '/question',
     properties: {
         fields: [
+            'is-proxy',
             'enter-question-body',
             'enter-unique-reference-number',
             'enter-name',

--- a/apps/pttg-rps-enquiry-form/translations/src/en/fields.json
+++ b/apps/pttg-rps-enquiry-form/translations/src/en/fields.json
@@ -75,5 +75,8 @@
       "required": "Enter your full name",
       "maxlength": "Full name must be fewer than 256 characters"
     }
+  },
+  "is-proxy": {
+    "label": "I am asking a question on behalf of somebody else"
   }
 }


### PR DESCRIPTION
The checkbox this commit adds is a small unstyled checkbox and not the
large GDS checkbox used on other Government services.

This is due to a bug in HOF's template mixins: for more information see
https://github.com/UKHomeOfficeForms/hof-template-mixins/pull/27

We're supposed to be able to override the problematic partial by
overriding it in apps/common/views/partials/forms/checkbox.html but it
doesn't seem to work.