### PR TITLE
Add DOB validation message when not real DOB

### DIFF
--- a/apps/pttg-rps-enquiry-form/fields/fields.js
+++ b/apps/pttg-rps-enquiry-form/fields/fields.js
@@ -52,7 +52,8 @@ module.exports = {
     'enter-date-of-birth': dateComponent('enter-date-of-birth', {
         validate: [
             {type: 'before'},
-            {type: 'after', arguments: '1903-01-01'}
+            {type: 'after', arguments: '1903-01-01'},
+            {type: 'date'}
         ]
     }),
     'is-proxy': {

--- a/apps/pttg-rps-enquiry-form/translations/src/en/fields.json
+++ b/apps/pttg-rps-enquiry-form/translations/src/en/fields.json
@@ -64,7 +64,7 @@
     "legend": "Date of Birth (optional)",
     "hint": "For example, 25 03 1957",
     "validation": {
-      "invalid": "Enter a real date of birth",
+      "date": "Enter a real date of birth",
       "before": "Date of birth must be in the past",
       "after": "Date of birth must be after 1902"
       }


### PR DESCRIPTION
When entering a not valid DOB we were not displaying the correct error message to the user. This fixes this issue.