### PR TITLE
Add heading-style labels on enquiry page

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -57,3 +57,19 @@
   display: none;
 }
 
+fieldset legend,
+.form-group .form-label {
+  @extend .heading-medium;
+
+  .form-hint {
+    margin-top: em(10, 16);
+    margin-bottom: em(5, 16);
+   }
+}
+
+/* More specific selectors override more general ones */
+.form-date .form-group .form-label {
+  margin: inherit;
+  padding: inherit;
+  @extend .form-label;
+}


### PR DESCRIPTION
This is a relatively sketchy CSS hack that might not work on all
browsers. It's a feature in the GOV.UK Design System, but not in GOV.UK Elements, that HOF uses.