### PR TITLE
align content of the confirmation page to match the start page

### DIFF
--- a/apps/pttg-rps-enquiry-form/views/content/en/confirmation.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/confirmation.md
@@ -1,3 +1,3 @@
 ## What happens next?
 
-You’ll get a reply to your email within 5 working days.
+We’ll reply within 5 working days.


### PR DESCRIPTION
The start page of the enquiry form highlights to the user that they will receive a response to their enquiry within 5 working days:
"We’ll reply within 5 working days."
This pull request marries up the confirmation page content with that of the start page.