### PR TITLE
EE-8768: Change links for buttons

### DIFF
--- a/apps/pttg-rps-enquiry-form/translations/src/en/buttons.json
+++ b/apps/pttg-rps-enquiry-form/translations/src/en/buttons.json
@@ -1,4 +1,4 @@
 {
     "start": "Start",
-    "need-more-help": "This doesn’t answer my question"
+    "go-to-enquiry": "Go to enquiry form"
 }

--- a/apps/pttg-rps-enquiry-form/views/about-the-scheme.html
+++ b/apps/pttg-rps-enquiry-form/views/about-the-scheme.html
@@ -4,7 +4,7 @@
             {{#markdown}}about-the-scheme{{/markdown}}
         </div>
         <div class="factsheet-submit">
-            {{#input-submit}}need-more-help{{/input-submit}}
+            {{#input-submit}}go-to-enquiry{{/input-submit}}
         </div>
     {{/page-content}}
 {{/partials-page}}

--- a/apps/pttg-rps-enquiry-form/views/content/en/about-the-scheme.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/about-the-scheme.md
@@ -34,3 +34,5 @@ It’ll be free to apply if:
 * you’re a child in local authority care
 
 [More about settled status](https://www.gov.uk/settled-status-eu-citizens-families)
+
+If this doesn't answer your question, use the enquiry form to send us an email. We'll reply within 5 working days.

--- a/apps/pttg-rps-enquiry-form/views/content/en/decision-factsheet.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/decision-factsheet.md
@@ -7,3 +7,5 @@ You will not lose your settled status unless you leave the UK for a period of mo
 If your application is unsuccessful, you can reapply if you do so by 30 June 2021. You can also appeal the decision if you apply from 30 March 2019.
 
 [More about who is eligible for settled status](https://www.gov.uk/settled-status-eu-citizens-families/eligibility)
+
+If this doesn't answer your question, use the enquiry form to send us an email. We'll reply within 5 working days.

--- a/apps/pttg-rps-enquiry-form/views/content/en/how-to-apply-factsheet.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/how-to-apply-factsheet.md
@@ -10,3 +10,5 @@ Full details of the scheme are still subject to approval by Parliament.
 </div>
 
 [More about applying for settled status](https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status)
+
+If this doesn't answer your question, use the enquiry form to send us an email. We'll reply within 5 working days.

--- a/apps/pttg-rps-enquiry-form/views/content/en/liveapp-factsheet.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/liveapp-factsheet.md
@@ -7,3 +7,5 @@ If your circumstances change while your application is being considered – for 
 You can withdraw your application at any time, but your fee will not be refunded.
 
 [More about applying for settled status](https://www.gov.uk/settled-status-eu-citizens-families/applying-for-settled-status)
+
+If this doesn't answer your question, use the enquiry form to send us an email. We'll reply within 5 working days.

--- a/apps/pttg-rps-enquiry-form/views/content/en/supporting-org-factsheet.md
+++ b/apps/pttg-rps-enquiry-form/views/content/en/supporting-org-factsheet.md
@@ -3,3 +3,5 @@
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque dui arcu, ornare eu felis non, pellentesque auctor dui. Curabitur vel finibus enim. Proin id scelerisque nisl, placerat condimentum sem. Phasellus metus nisi, pharetra at orci vel, congue euismod purus. Suspendisse vel facilisis dui. Donec imperdiet dignissim bibendum. Donec nec maximus risus, vitae hendrerit diam. Vivamus suscipit vestibulum euismod. Maecenas rutrum tristique congue. Vivamus eget posuere risus. Quisque eu elit sit amet nisi varius ultrices.
 
 Integer sed viverra risus. Proin mollis accumsan nulla, vitae blandit nibh venenatis in. Cras in ultrices massa. Quisque metus ligula, gravida vitae aliquam sit amet, interdum non neque. Donec porta dapibus lorem, in rhoncus dolor porta non. Integer elementum turpis ipsum, id malesuada velit dignissim a. Suspendisse potenti. Donec in ante quis neque sollicitudin viverra. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae.
+
+If this doesn't answer your question, use the enquiry form to send us an email. We'll reply within 5 working days.

--- a/apps/pttg-rps-enquiry-form/views/decision-factsheet.html
+++ b/apps/pttg-rps-enquiry-form/views/decision-factsheet.html
@@ -2,7 +2,7 @@
     {{$page-content}}
         <div id="markdown">{{#markdown}}decision-factsheet{{/markdown}}</div>
         <div class="factsheet-submit">
-            {{#input-submit}}need-more-help{{/input-submit}}
+            {{#input-submit}}go-to-enquiry{{/input-submit}}
         </div>
     {{/page-content}}
 {{/partials-page}}

--- a/apps/pttg-rps-enquiry-form/views/how-to-apply-factsheet.html
+++ b/apps/pttg-rps-enquiry-form/views/how-to-apply-factsheet.html
@@ -4,7 +4,7 @@
             {{#markdown}}how-to-apply-factsheet{{/markdown}}
         </div>
         <div class="factsheet-submit">
-            {{#input-submit}}need-more-help{{/input-submit}}
+            {{#input-submit}}go-to-enquiry{{/input-submit}}
         </div>
     {{/page-content}}
 {{/partials-page}}

--- a/apps/pttg-rps-enquiry-form/views/live-application-factsheet.html
+++ b/apps/pttg-rps-enquiry-form/views/live-application-factsheet.html
@@ -2,7 +2,7 @@
     {{$page-content}}
         <div id="markdown">{{#markdown}}liveapp-factsheet{{/markdown}}</div>
         <div class="factsheet-submit">
-            {{#input-submit}}need-more-help{{/input-submit}}
+            {{#input-submit}}go-to-enquiry{{/input-submit}}
         </div>
     {{/page-content}}
 {{/partials-page}}

--- a/apps/pttg-rps-enquiry-form/views/supporting-org-factsheet.html
+++ b/apps/pttg-rps-enquiry-form/views/supporting-org-factsheet.html
@@ -4,7 +4,7 @@
             {{#markdown}}supporting-org-factsheet{{/markdown}}
         </div>
         <div class="factsheet-submit">
-            {{#input-submit}}need-more-help{{/input-submit}}
+            {{#input-submit}}go-to-enquiry{{/input-submit}}
         </div>
     {{/page-content}}
 {{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -20,30 +20,6 @@
   width: 100%;
 }
 
-.factsheet-submit input {
-  @extend a;
-  color: #005ea5;
-  box-shadow: none;
-  background: none;
-  text-decoration: underline;
-  margin-top: 1.5rem;
-}
-
-.factsheet-submit input:visited {
-  color: #4c2c92;
-  background: none;
-}
-
-.factsheet-submit input:hover {
-  color: #2e8aca;
-  background: none;
-}
-
-.factsheet-submit input:active {
-  color: #2e8aca;
-  background: none;
-}
-
 .table-details tbody td:nth-child(2) {
   word-break: break-word;
 }


### PR DESCRIPTION
- This concerns each of the factsheet pages on the enquiry form.

- We now add some additional text to guide the user and change the link to the enquiry form to a gov.uk style green button.

- Label for the button has also been adjusted to better reflect the content of the button.

- The link was always a button but it was previously styled to look like a hyperlink. This styling has now been removed.

- Content can be cross checked in the Jira ticket.