### PR TITLE
EE-16908 fix secret

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -109,8 +109,7 @@ pipeline:
       - pttg_rps_dev
       - pttg_rps_test
       - basic_auth
-      - notify_recipient_dev
-      - notify_recipient_test
+      - notify_recipient_notprod
     commands:
       - cd kube-pttg-rps-enquiry-form
       - ./deploy.sh


### PR DESCRIPTION
Changed the notify_recipient secret for notprod used by drone deployment to match that expected by the deploy.sh script in kube project.