### PR TITLE
[EE-36648] Fix for redirect issue cause by cookie middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ settings.start = false;
 
 const app = hof(settings);
 
+app.use(function(req, res, next) {
+    const isPotentialDodgyRedirect = req.path.startsWith('//');
+    isPotentialDodgyRedirect ?
+        res.redirect("/") :
+        next();
+});
+
 //Endpoint for Notify delivery receipts
 app.use('/notify-messages', notifyMessages);
 


### PR DESCRIPTION
Redirect to the root path if the url looks like it may contain something like //google.co.uk before it reaches the unsafe redirect in the hof-middleware cookie package.